### PR TITLE
Fix request payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -341,10 +341,7 @@ for (const token of tokens) {
                     "Content-Type": "application/json",
                     "Content-Length": payload.length
                 },
-                data: {
-                	"channel_id": msg.channel.id,
-                	"payment_source_id": paymentsourceid
-                }
+                data: `{"channel_id":${msg.channel.id},"payment_source_id":${paymentsourceid}}`
             }, (err, res) => {
                 let end = `${new Date() - start}ms`;
                 if (err) {


### PR DESCRIPTION
Fixes #36 - only happens with invalid codes from what I've seen.
Uses the same code on my test repo. I'm not sure how this works, maybe something with phin adding quotes in the data field and messing up the payload.length. Shouldn't that also affect valid codes? Doesn't look like it.